### PR TITLE
added support for the Business API

### DIFF
--- a/googlemaps/src/main/java/com/vaadin/tapio/googlemaps/GoogleMap.java
+++ b/googlemaps/src/main/java/com/vaadin/tapio/googlemaps/GoogleMap.java
@@ -98,12 +98,17 @@ public class GoogleMap extends com.vaadin.ui.AbstractComponent {
      * Initiates a new GoogleMap object with default settings from the
      * {@link GoogleMapState state object}.
      * 
-     * @param apiKey
-     *            The Maps API key from Google. Not required when developing in
-     *            localhost.
+     * @param apiKeyOrClientId
+     *            The Maps API key from Google or the client ID for the
+     *            Business API. All client IDs begin with a gme- prefix.
+     *            Not required when developing in localhost.
      */
-    public GoogleMap(String apiKey) {
-        getState().apiKey = apiKey;
+    public GoogleMap(String apiKeyOrClientId) {
+    	if (isClientId(apiKeyOrClientId)) {
+    		getState().clientId = apiKeyOrClientId;
+    	} else {
+    		getState().apiKey = apiKeyOrClientId;
+    	}
         registerRpc(markerClickedRpc);
         registerRpc(mapMovedRpc);
         registerRpc(markerDraggedRpc);
@@ -116,12 +121,13 @@ public class GoogleMap extends com.vaadin.ui.AbstractComponent {
      * 
      * @param center
      *            Coordinates of the center.
-     * @param apiKey
-     *            The Maps API key from Google. Not required when developing in
-     *            localhost.
+     * @param apiKeyOrClientId
+     *            The Maps API key from Google or the client ID for the
+     *            Business API. All client IDs begin with a gme- prefix.
+     *            Not required when developing in localhost.
      */
-    public GoogleMap(LatLon center, String apiKey) {
-        this(apiKey);
+    public GoogleMap(LatLon center, String apiKeyOrClientId) {
+        this(apiKeyOrClientId);
         getState().center = center;
     }
 
@@ -133,12 +139,13 @@ public class GoogleMap extends com.vaadin.ui.AbstractComponent {
      *            Coordinates of the center.
      * @param zoom
      *            Amount of zoom.
-     * @param apiKey
-     *            The Maps API key from Google. Not required when developing in
-     *            localhost.
+     * @param apiKeyOrClientId
+     *            The Maps API key from Google or the client ID for the
+     *            Business API. All client IDs begin with a gme- prefix.
+     *            Not required when developing in localhost.
      */
-    public GoogleMap(LatLon center, double zoom, String apiKey) {
-        this(apiKey);
+    public GoogleMap(LatLon center, double zoom, String apiKeyOrClientId) {
+        this(apiKeyOrClientId);
         getState().zoom = zoom;
         getState().center = center;
     }
@@ -152,16 +159,17 @@ public class GoogleMap extends com.vaadin.ui.AbstractComponent {
      *            Coordinates of the center.
      * @param zoom
      *            Amount of zoom.
-     * @param apiKey
-     *            The Maps API key from Google. Not required when developing in
-     *            localhost.
+     * @param apiKeyOrClientId
+     *            The Maps API key from Google or the client ID for the
+     *            Business API. All client IDs begin with a gme- prefix.
+     *            Not required when developing in localhost.
      * @param language
      *            The language to use with maps. See
      *            https://developers.google.com/maps/faq#languagesupport for the
      *            list of the supported languages.
      */
-    public GoogleMap(LatLon center, double zoom, String apiKey, String language) {
-        this(apiKey);
+    public GoogleMap(LatLon center, double zoom, String apiKeyOrClientId, String language) {
+        this(apiKeyOrClientId);
         getState().zoom = zoom;
         getState().center = center;
         getState().language = language;
@@ -692,5 +700,9 @@ public class GoogleMap extends com.vaadin.ui.AbstractComponent {
     public void fitToBounds(LatLon boundsNE, LatLon boundsSW) {
         getState().fitToBoundsNE = boundsNE;
         getState().fitToBoundsSW = boundsSW;
+    }
+    
+    private boolean isClientId(String apiKeyOrClientId) {
+    	return apiKeyOrClientId != null && apiKeyOrClientId.startsWith("gme-");
     }
 }

--- a/googlemaps/src/main/java/com/vaadin/tapio/googlemaps/client/GoogleMapConnector.java
+++ b/googlemaps/src/main/java/com/vaadin/tapio/googlemaps/client/GoogleMapConnector.java
@@ -194,13 +194,18 @@ public class GoogleMapConnector extends AbstractComponentConnector implements
         if (getState().language != null) {
             otherParams.append("&language=" + getState().language);
         }
+        if (getState().isBusiness()) {
+        	otherParams.append("&client=" + getState().clientId);
+        }
         options.setOtherParms(otherParams.toString());
         Runnable callback = new Runnable() {
             public void run() {
                 initMap();
             }
         };
-        AjaxLoader.init(getState().apiKey);
+        if (!getState().isBusiness()) {
+        	AjaxLoader.init(getState().apiKey);
+        }
         AjaxLoader.loadApi("maps", "3", callback, options);
     }
 

--- a/googlemaps/src/main/java/com/vaadin/tapio/googlemaps/client/GoogleMapState.java
+++ b/googlemaps/src/main/java/com/vaadin/tapio/googlemaps/client/GoogleMapState.java
@@ -17,6 +17,7 @@ public class GoogleMapState extends AbstractComponentState {
     private static final long serialVersionUID = 646346522643L;
 
     public String apiKey = null;
+    public String clientId = null;
 
     // defaults to the language setting of the browser
     public String language = null;
@@ -55,5 +56,9 @@ public class GoogleMapState extends AbstractComponentState {
     public Map<Long, GoogleMapMarker> markers = new HashMap<Long, GoogleMapMarker>();
 
     public Map<Long, GoogleMapInfoWindow> infoWindows = new HashMap<Long, GoogleMapInfoWindow>();
+    
+    public boolean isBusiness() {
+    	return clientId != null;
+    }
 
 }


### PR DESCRIPTION
Thanks for the great add-on.
I added a few lines of code to support the use of a Business client ID (to access the Business API) instead of a regular API key.
For reference, see https://developers.google.com/maps/documentation/business/clientside/auth
